### PR TITLE
Feature/us5/display folders

### DIFF
--- a/components/BackButton/BackButton.js
+++ b/components/BackButton/BackButton.js
@@ -1,6 +1,8 @@
 import styled from "styled-components";
-import { ArrowLeftLong } from "../svgs";
+// Hooks
 import { useRouter } from "next/router";
+// SVGs
+import { ArrowLeftLong } from "../svgs";
 
 const BackButton = () => {
   const router = useRouter();

--- a/components/Breadcrumb/index.js
+++ b/components/Breadcrumb/index.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
+// Hooks
+import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
-import { useState } from "react";
-import { useEffect } from "react";
 
 const Breadcrumb = () => {
   const [breadcrumbText, setBreadcrumbText] = useState("");

--- a/components/FolderPreviewIcon/index.js
+++ b/components/FolderPreviewIcon/index.js
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import styled from "styled-components";
+// SVGs
 import { FolderIcon } from "../svgs";
 
 const FolderPreviewIcon = ({ data }) => {

--- a/components/FolderPreviewIcon/index.js
+++ b/components/FolderPreviewIcon/index.js
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import styled from "styled-components";
+import { FolderIcon } from "../svgs";
+
+const FolderPreviewIcon = ({ data }) => {
+  return (
+    <StyledFolder>
+      <StyledFolderIcon foldercolor={data.folderColor} />
+      <StyledParagraphText>{data.folderName}</StyledParagraphText>
+    </StyledFolder>
+  );
+};
+
+export default FolderPreviewIcon;
+
+const StyledFolderIcon = styled(FolderIcon)`
+  z-index: 0;
+  width: 100%;
+  height: 60%;
+  color: ${({ foldercolor }) => foldercolor};
+`;
+
+const StyledFolder = styled.div`
+  z-index: 1;
+  width: 30%;
+  text-decoration: none;
+  color: inherit;
+`;
+
+const StyledParagraphText = styled.p`
+  text-align: center;
+  width: 100%;
+  font-size: 75%;
+  font-weight: 600;
+  position: relative;
+  bottom: 5%;
+`;

--- a/components/FolderPreviewList/index.js
+++ b/components/FolderPreviewList/index.js
@@ -1,0 +1,47 @@
+import styled from "styled-components";
+import { useState, useEffect } from "react";
+import FolderPreviewIcon from "../FolderPreviewIcon";
+import NewFolderButton from "../NewFolderButton";
+
+const FolderPreviewList = () => {
+  const [dataFolders, setDataFolders] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const response = await fetch("/api/folders", {
+          method: "GET",
+        });
+
+        if (response.ok) {
+          const jsonData = await response.json();
+          const cleanData = jsonData.data;
+          setDataFolders(cleanData);
+        }
+      } catch (error) {
+        throw new Error(error.message);
+      }
+    })();
+  }, []);
+
+  if (dataFolders === []) return;
+
+  return (
+    <StyledFolderPreviewList>
+      {dataFolders.map((folderData) => {
+        return <FolderPreviewIcon key={folderData._id} data={folderData} />;
+      })}
+      <NewFolderButton />
+    </StyledFolderPreviewList>
+  );
+};
+
+export default FolderPreviewList;
+
+const StyledFolderPreviewList = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  width: 90%;
+  margin: 20px 0 20px 5%;
+  column-gap: 5%;
+`;

--- a/components/FolderPreviewList/index.js
+++ b/components/FolderPreviewList/index.js
@@ -1,5 +1,7 @@
 import styled from "styled-components";
+// Hooks
 import { useState, useEffect } from "react";
+
 import FolderPreviewIcon from "../FolderPreviewIcon";
 import NewFolderButton from "../NewFolderButton";
 

--- a/components/Headline/index.test.js
+++ b/components/Headline/index.test.js
@@ -1,5 +1,6 @@
-import Headline from ".";
 import { render, screen } from "@testing-library/react";
+// Components
+import Headline from ".";
 
 test("Rendered Headline contains text ARO", () => {
   render(<Headline>ARO</Headline>);

--- a/components/NewFolderButton/index.js
+++ b/components/NewFolderButton/index.js
@@ -46,7 +46,7 @@ const StyledLink = styled(Link)`
 const StyledParagraphText = styled.p`
   text-align: center;
   font-size: 0.9rem;
-  font-weight: 700;
+  font-weight: 900;
   position: relative;
   bottom: 110px;
 `;

--- a/components/NewFolderButton/index.js
+++ b/components/NewFolderButton/index.js
@@ -1,6 +1,7 @@
 import styled from "styled-components";
-import { FolderIcon, PlusIcon } from "../svgs";
 import Link from "next/link";
+// SVGs
+import { FolderIcon, PlusIcon } from "../svgs";
 
 const NewFolderButton = () => {
   return (

--- a/components/NewFolderForm/index.js
+++ b/components/NewFolderForm/index.js
@@ -12,7 +12,12 @@ const NewFolderForm = () => {
   return (
     <form onSubmit={handleOnSubmit}>
       <StyledFolderIcon foldercolor={folderColor} />
-      <StyledInput type="text" name="folderName" />
+      <StyledInput
+        type="text"
+        name="folderName"
+        placeholder="Enter here your folder name."
+        required
+      />
       <StyledButtons>
         <StyledColorPickButton
           colorvalue={"#38b"}

--- a/components/NewFolderForm/index.js
+++ b/components/NewFolderForm/index.js
@@ -1,7 +1,9 @@
 import styled from "styled-components";
-import { FolderIcon, PlusIcon } from "../svgs";
+// Hooks
 import { useState } from "react";
 import { useRouter } from "next/router";
+// SVGs
+import { FolderIcon, PlusIcon } from "../svgs";
 
 const NewFolderForm = () => {
   const router = useRouter();

--- a/components/RecentUploads/index.js
+++ b/components/RecentUploads/index.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
-import { useState } from "react";
-import { useEffect } from "react";
+// Hooks
+import { useState, useEffect } from "react";
 
 const RecentUploads = () => {
   const [text, setText] = useState("Recent Uploads");

--- a/components/SideBar/index.js
+++ b/components/SideBar/index.js
@@ -61,6 +61,7 @@ const StyledLinks = styled.div`
 `;
 
 const StyledSideBarBackground = styled.div`
+  z-index: 99;
   position: fixed;
   top: 0;
   width: 100vw;

--- a/components/SideBar/index.js
+++ b/components/SideBar/index.js
@@ -1,6 +1,7 @@
 import styled from "styled-components";
-import { useRouter } from "next/router";
 import Link from "next/link";
+// Hooks
+import { useRouter } from "next/router";
 
 const SideBar = ({ sideBarOpen, setSideBarOpen }) => {
   const router = useRouter();

--- a/components/SideBarButton/index.js
+++ b/components/SideBarButton/index.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+// SVGs
 import { BurgerIcon, XIcon } from "../svgs";
 
 const SidebarButton = ({ sideBarOpen, setSideBarOpen }) => {

--- a/db/models/Folder.js
+++ b/db/models/Folder.js
@@ -2,13 +2,16 @@ import mongoose from "mongoose";
 
 const { Schema } = mongoose;
 
-const folderSchema = new Schema({
-  folderName: {
-    type: String,
-    required: true,
+const folderSchema = new Schema(
+  {
+    folderName: {
+      type: String,
+      required: true,
+    },
+    folderColor: String,
   },
-  folderColor: String,
-});
+  { collection: "folders" }
+);
 
 const Folder = mongoose.models.Folder || mongoose.model("Folder", folderSchema);
 

--- a/pages/api/folder.js
+++ b/pages/api/folder.js
@@ -1,4 +1,5 @@
 import dbConnect from "../../db/connect.js";
+// Models
 import Folder from "../../db/models/Folder.js";
 
 const handler = async (request, response) => {

--- a/pages/api/folders.js
+++ b/pages/api/folders.js
@@ -1,0 +1,25 @@
+import dbConnect from "../../db/connect.js";
+import Folder from "../../db/models/Folder.js";
+
+const handler = async (request, response) => {
+  await dbConnect();
+
+  if (request.method === "GET") {
+    try {
+      const folders = await Folder.find();
+
+      response
+        .status(200)
+        .json({ status: "Successful folders fetch!", data: folders });
+    } catch (error) {
+      console.log(error);
+
+      response
+        .status(400)
+        .json({ status: "Failed to get folders!", error: error.message });
+      return;
+    }
+  }
+};
+
+export default handler;

--- a/pages/api/folders.js
+++ b/pages/api/folders.js
@@ -1,4 +1,5 @@
 import dbConnect from "../../db/connect.js";
+// Models
 import Folder from "../../db/models/Folder.js";
 
 const handler = async (request, response) => {

--- a/pages/content.js
+++ b/pages/content.js
@@ -1,3 +1,4 @@
+// Components
 import BackButton from "../components/BackButton/BackButton";
 import CommonHeaderLayout from "../components/CommonHeaderLayout";
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,6 @@
 // Components
 import CommonHeaderLayout from "../components/CommonHeaderLayout";
-import NewFolderButton from "../components/NewFolderButton";
+import FolderPreviewList from "../components/FolderPreviewList";
 import RecentUploads from "../components/RecentUploads";
 
 export default function Home({ sideBarOpen, setSideBarOpen }) {
@@ -10,7 +10,7 @@ export default function Home({ sideBarOpen, setSideBarOpen }) {
         sideBarOpen={sideBarOpen}
         setSideBarOpen={setSideBarOpen}
       />
-      <NewFolderButton />
+      <FolderPreviewList />
       <RecentUploads />
     </main>
   );

--- a/pages/new-folder.js
+++ b/pages/new-folder.js
@@ -1,3 +1,4 @@
+// Components
 import BackButton from "../components/BackButton/BackButton";
 import CommonHeaderLayout from "../components/CommonHeaderLayout";
 import NewFolderForm from "../components/NewFolderForm";


### PR DESCRIPTION
Please take a moment to review this ❤️ 
Goal: [US5](https://github.com/dimitriosxmi/ArtistsReferenceOrganizer/issues/5) TL; DR Add a `Folder preview list` of `Folder preview icon`'s in the dashboard `/` route page, i.e.:
![Screenshot_6](https://github.com/dimitriosxmi/ArtistsReferenceOrganizer/assets/31593501/372d1e56-f305-4015-ae94-2321b22bcd85)

[Deployment](https://artists-reference-organizer-otg9rtx9y-dimitriosxmi.vercel.app/)

```diff
+ Add api/folders.js
# Handles Get request for all folders.

+ Add FolderPreviewIcon component
# Displays preview of folder icon with name and proper color to the icon.

+ Add FolderPreviewList component
# Fetches all folders using api/folders.js GET method adn displays a list
# of FolderPreviewIcon's component and displayes additionally at the
# end the NewFolderButton component.

! Update pages/index.js
# Replace NewFolderButton component with FolderPreviewList component.

! Update Folder model
# Add previously forgotten specification to the correct collection.

! Update NewFolderButton component
# Miniscule styling changes.

! Update SideBar component
# Miniscule styling changes.
```