### PR TITLE
Feature/us6/new entry button and form

### DIFF
--- a/components/Breadcrumb/index.js
+++ b/components/Breadcrumb/index.js
@@ -24,6 +24,9 @@ const Breadcrumb = () => {
         case "/new-folder":
           setBreadcrumbText("(NEW FOLDER)");
           break;
+        case "/new-entry":
+          setBreadcrumbText("(NEW ENTRY)");
+          break;
         default:
           setBreadcrumbText("Unknown Page");
           break;

--- a/components/NewEntryButton/index.js
+++ b/components/NewEntryButton/index.js
@@ -1,0 +1,55 @@
+import styled from "styled-components";
+import Link from "next/link";
+// SVGs
+import { EntryFileIcon, PlusIcon } from "../svgs";
+
+const NewEntryButton = () => {
+  return (
+    <StyledLink href="/new-entry">
+      <StyledEntryFileIcon />
+      <StyledPlusIcon />
+      <StyledParagraphText>(NEW ENTRY)</StyledParagraphText>
+    </StyledLink>
+  );
+};
+
+export default NewEntryButton;
+
+const StyledEntryFileIcon = styled(EntryFileIcon)`
+  position: relative;
+  z-index: 1;
+  width: 70px;
+  height: 90px;
+  color: #40cc90;
+  left: 30px;
+  bottom: 0px;
+`;
+
+const StyledPlusIcon = styled(PlusIcon)`
+  position: relative;
+  z-index: 2;
+  width: 90px;
+  height: 90px;
+  bottom: 80px;
+  right: 0px;
+`;
+
+const StyledLink = styled(Link)`
+  display: block;
+  z-index: 3;
+  position: fixed;
+  bottom: 1%;
+  right: 5%;
+  width: 100px;
+  height: 100px;
+  text-decoration: none;
+  color: inherit;
+`;
+
+const StyledParagraphText = styled.p`
+  text-align: center;
+  font-size: 0.9rem;
+  font-weight: 900;
+  position: relative;
+  bottom: 225%;
+`;

--- a/components/NewEntryForm/index.js
+++ b/components/NewEntryForm/index.js
@@ -1,0 +1,69 @@
+import styled from "styled-components";
+// Hooks
+import { useRouter } from "next/router";
+// SVGs
+import { PlusIcon } from "../svgs";
+
+const NewEntryForm = () => {
+  const router = useRouter();
+
+  return (
+    <form onSubmit={handleOnSubmit}>
+      <StyledInput
+        type="text"
+        name="entryName"
+        placeholder="Enter here your entry name."
+        required
+      />
+      <br />
+      <StyledSubmitButton type="submit">
+        <StyledPlusIcon />
+      </StyledSubmitButton>
+    </form>
+  );
+
+  async function handleOnSubmit(event) {
+    event.preventDefault();
+    const formData = new FormData(event.target);
+    const data = Object.fromEntries(formData);
+    console.log(data);
+    const response = await fetch("/api/entry", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (response.ok) {
+      router.push("/");
+    }
+  }
+};
+
+export default NewEntryForm;
+
+const StyledInput = styled.input`
+  margin: 20px 0 20px 5%;
+  border: 2px dashed #448;
+  width: 90%;
+  height: 2rem;
+  padding: 0.5rem;
+  text-overflow: ellipsis;
+`;
+
+const StyledPlusIcon = styled(PlusIcon)`
+  height: 100%;
+  width: 100%;
+`;
+
+const StyledSubmitButton = styled.button`
+  position: fixed;
+  bottom: 0;
+  width: 90%;
+  height: 60px;
+  margin: 30px 0 30px 5%;
+  border: 2px solid #223;
+  border-radius: 10px;
+  background: #40cc90;
+`;

--- a/components/RecentUploads/index.js
+++ b/components/RecentUploads/index.js
@@ -30,4 +30,5 @@ const StyledRecentUploadsText = styled.p`
   width: 90%;
   margin-left: 5%;
   margin-top: 100px;
+  margin-bottom: 200px;
 `;

--- a/components/svgs/EntryFileIcon.svg
+++ b/components/svgs/EntryFileIcon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M0 64C0 28.7 28.7 0 64 0H224V128c0 17.7 14.3 32 32 32H384V448c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V64zm384 64H256V0L384 128z" fill="currentColor"/></svg>

--- a/components/svgs/index.js
+++ b/components/svgs/index.js
@@ -3,3 +3,4 @@ export { default as XIcon } from "./XIcon.svg";
 export { default as ArrowLeftLong } from "./ArrowLeftLongIcon.svg";
 export { default as FolderIcon } from "./FolderIcon.svg";
 export { default as PlusIcon } from "./PlusIcon.svg";
+export { default as EntryFileIcon } from "./EntryFileIcon.svg";

--- a/db/models/Entry.js
+++ b/db/models/Entry.js
@@ -1,0 +1,32 @@
+import mongoose from "mongoose";
+
+const { Schema } = mongoose;
+
+const entrySchema = new Schema(
+  {
+    entryName: {
+      type: String,
+      required: true,
+    },
+    entryUploadFile: {
+      type: String,
+    },
+    entryReferenceLink: {
+      type: String,
+    },
+    entryDescription: {
+      type: String,
+    },
+    entryTags: {
+      type: [String],
+    },
+    entrySelectedFolder: {
+      type: String,
+    },
+  },
+  { collection: "entries" }
+);
+
+const Entry = mongoose.models.Entry || mongoose.model("Entry", entrySchema);
+
+export default Entry;

--- a/pages/api/entry.js
+++ b/pages/api/entry.js
@@ -1,0 +1,27 @@
+import dbConnect from "../../db/connect.js";
+// Models
+import Entry from "../../db/models/Entry.js";
+
+const handler = async (request, response) => {
+  await dbConnect();
+
+  if (request.method === "POST") {
+    try {
+      const entry = request.body;
+      console.log(entry);
+      await Entry.create(entry);
+
+      response.status(201).json({ status: "Success entry post!" });
+      return;
+    } catch (error) {
+      console.log(error);
+
+      response
+        .status(400)
+        .json({ status: "Failed to post entry!", error: error.message });
+      return;
+    }
+  }
+};
+
+export default handler;

--- a/pages/api/folder.js
+++ b/pages/api/folder.js
@@ -10,7 +10,7 @@ const handler = async (request, response) => {
       const folder = request.body;
       await Folder.create(folder);
 
-      response.status(200).json({ status: "Success: Created Folder" });
+      response.status(201).json({ status: "Success: Created Folder" });
       return;
     } catch (error) {
       console.log(error);

--- a/pages/content.js
+++ b/pages/content.js
@@ -1,6 +1,7 @@
 // Components
-import BackButton from "../components/BackButton/BackButton";
 import CommonHeaderLayout from "../components/CommonHeaderLayout";
+import BackButton from "../components/BackButton/BackButton";
+import NewEntryButton from "../components/NewEntryButton";
 
 const Content = ({ sideBarOpen, setSideBarOpen }) => {
   return (
@@ -10,6 +11,7 @@ const Content = ({ sideBarOpen, setSideBarOpen }) => {
         setSideBarOpen={setSideBarOpen}
       />
       <BackButton />
+      <NewEntryButton />
     </>
   );
 };

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@
 import CommonHeaderLayout from "../components/CommonHeaderLayout";
 import FolderPreviewList from "../components/FolderPreviewList";
 import RecentUploads from "../components/RecentUploads";
+import NewEntryButton from "../components/NewEntryButton";
 
 export default function Home({ sideBarOpen, setSideBarOpen }) {
   return (
@@ -12,6 +13,7 @@ export default function Home({ sideBarOpen, setSideBarOpen }) {
       />
       <FolderPreviewList />
       <RecentUploads />
+      <NewEntryButton />
     </main>
   );
 }

--- a/pages/new-entry.js
+++ b/pages/new-entry.js
@@ -1,0 +1,19 @@
+// Components
+import CommonHeaderLayout from "../components/CommonHeaderLayout";
+import BackButton from "../components/BackButton/BackButton";
+import NewEntryForm from "../components/NewEntryForm";
+
+const NewEntry = ({ sideBarOpen, setSideBarOpen }) => {
+  return (
+    <>
+      <CommonHeaderLayout
+        sideBarOpen={sideBarOpen}
+        setSideBarOpen={setSideBarOpen}
+      />
+      <BackButton />
+      <NewEntryForm />
+    </>
+  );
+};
+
+export default NewEntry;


### PR DESCRIPTION
Please take a moment to review ❤️

Goal: [US6](https://github.com/dimitriosxmi/ArtistsReferenceOrganizer/issues/6) TL; DR: Add `New entry` button at dashboard and content page, `New entry` button navigates to `/new-entry` page which contains `New entry form` with submit button that sends data to the database aka:
![Screenshot_9](https://github.com/dimitriosxmi/ArtistsReferenceOrganizer/assets/31593501/bb1f82da-718b-427f-a311-90f88b27c80f)
and navigates back to dashboard `/` route on success!

[Deployment](https://artists-reference-organizer-gp62d9tb9-dimitriosxmi.vercel.app/)

```diff
+ Add EntryFileIcon svg
! Update components/svg/index.js
# Exports the added svg.

+ Add Entry model
# Currently only the entryName field is required.

+ Add pages/api/entry.js api page
# Handles POST method for entry creation.

+ Add NewEntryForm component
# Contains the form of entry creation and handles the POST request.

+ Add pages/new-entry.js page
# Uses the NewEntryForm component.

+ Add NewEntryButton component
# Opens up the NewEntry page.

! Update pages/index.js page
# Now uses the NewEntryButton component.

! Update pages/content.js  page
# Now uses the NewEntryButton component.

! Update pages/api/folder.js api page
# Fix status code typo for POST method.

! Update Breadcrumb component
# Add support for NewEntry page.

! Update RecentUploads component
# Miniscule styling changes.
```
