### PR TITLE
Feature/us7/display entries

### DIFF
--- a/components/EntryPreview/index.js
+++ b/components/EntryPreview/index.js
@@ -1,0 +1,32 @@
+import styled from "styled-components";
+
+const EntryPreview = ({ entryData }) => {
+  return (
+    <StyledEntryPreviewCard>
+      <StyledEntryName>{entryData.entryName}</StyledEntryName>
+    </StyledEntryPreviewCard>
+  );
+};
+
+export default EntryPreview;
+
+const StyledEntryPreviewCard = styled.div`
+  width: 90%;
+  height: 75px;
+  margin: 5px 0 5px 5%;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center;
+  align-items: center;
+  white-space: nowrap;
+  border: 2px solid #223;
+  border-radius: 5px;
+`;
+
+const StyledEntryName = styled.p`
+  margin: 0;
+  padding: 3px;
+  font-size: 1.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/components/EntryPreviewList/index.js
+++ b/components/EntryPreviewList/index.js
@@ -20,7 +20,7 @@ const EntryPreviewList = ({ recentEntriesAmount, hasData }) => {
             const jsonData = await response.json();
             const cleanData = jsonData.data;
             setEntries(cleanData);
-            hasData(cleanData);
+            if (hasData) hasData(cleanData);
           }
         }
         //#endregion
@@ -32,7 +32,7 @@ const EntryPreviewList = ({ recentEntriesAmount, hasData }) => {
             const jsonData = await response.json();
             const cleanData = jsonData.data;
             setEntries(cleanData);
-            hasData(cleanData);
+            if (hasData) hasData(cleanData);
           }
         }
         //#endregion

--- a/components/EntryPreviewList/index.js
+++ b/components/EntryPreviewList/index.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 // Components
 import EntryPreview from "../EntryPreview";
 
-const EntryPreviewList = ({ recentEntries, hasData }) => {
+const EntryPreviewList = ({ recentEntriesAmount, hasData }) => {
   const [entries, setEntries] = useState([]);
 
   //#region Get entries from database
@@ -11,9 +11,9 @@ const EntryPreviewList = ({ recentEntries, hasData }) => {
     (async () => {
       try {
         //#region Get # most recent entries
-        if (recentEntries) {
+        if (recentEntriesAmount) {
           const response = await fetch(
-            `/api/entries?recentEntries=${recentEntries}`
+            `/api/entries?recentEntriesAmount=${recentEntriesAmount}`
           );
 
           if (response.ok) {

--- a/components/EntryPreviewList/index.js
+++ b/components/EntryPreviewList/index.js
@@ -1,0 +1,54 @@
+// Hooks
+import { useState, useEffect } from "react";
+// Components
+import EntryPreview from "../EntryPreview";
+
+const EntryPreviewList = ({ recentEntries, hasData }) => {
+  const [entries, setEntries] = useState([]);
+
+  //#region Get entries from database
+  useEffect(() => {
+    (async () => {
+      try {
+        //#region Get # most recent entries
+        if (recentEntries) {
+          const response = await fetch(
+            `/api/entries?recentEntries=${recentEntries}`
+          );
+
+          if (response.ok) {
+            const jsonData = await response.json();
+            const cleanData = jsonData.data;
+            setEntries(cleanData);
+            hasData(cleanData);
+          }
+        }
+        //#endregion
+        //#region Get all entries
+        else {
+          const response = await fetch("/api/entries");
+
+          if (response.ok) {
+            const jsonData = await response.json();
+            const cleanData = jsonData.data;
+            setEntries(cleanData);
+            hasData(cleanData);
+          }
+        }
+        //#endregion
+      } catch (error) {
+        console.log(error);
+        throw new Error(error.message);
+      }
+    })();
+  }, []);
+  //#endregion
+
+  if (!entries) return <p>Loading entries..</p>;
+
+  return entries.map((entryData) => {
+    return <EntryPreview key={entryData._id} entryData={entryData} />;
+  });
+};
+
+export default EntryPreviewList;

--- a/components/NewEntryForm/index.js
+++ b/components/NewEntryForm/index.js
@@ -26,7 +26,7 @@ const NewEntryForm = () => {
     event.preventDefault();
     const formData = new FormData(event.target);
     const data = Object.fromEntries(formData);
-    console.log(data);
+    data.entryUploadDate = new Date().valueOf();
     const response = await fetch("/api/entry", {
       method: "POST",
       headers: {

--- a/components/RecentUploads/index.js
+++ b/components/RecentUploads/index.js
@@ -19,7 +19,7 @@ const RecentUploads = () => {
   return (
     <section>
       <StyledRecentUploadsText>{text}</StyledRecentUploadsText>
-      <EntryPreviewList recentEntries={20} hasData={setData} />
+      <EntryPreviewList recentEntriesAmount={20} hasData={setData} />
     </section>
   );
 };

--- a/components/RecentUploads/index.js
+++ b/components/RecentUploads/index.js
@@ -1,6 +1,8 @@
 import styled from "styled-components";
 // Hooks
 import { useState, useEffect } from "react";
+// Components
+import EntryPreviewList from "../EntryPreviewList";
 
 const RecentUploads = () => {
   const [text, setText] = useState("Recent Uploads");
@@ -17,6 +19,7 @@ const RecentUploads = () => {
   return (
     <section>
       <StyledRecentUploadsText>{text}</StyledRecentUploadsText>
+      <EntryPreviewList recentEntries={20} hasData={setData} />
     </section>
   );
 };
@@ -30,5 +33,4 @@ const StyledRecentUploadsText = styled.p`
   width: 90%;
   margin-left: 5%;
   margin-top: 100px;
-  margin-bottom: 200px;
 `;

--- a/db/models/Entry.js
+++ b/db/models/Entry.js
@@ -23,6 +23,10 @@ const entrySchema = new Schema(
     entrySelectedFolder: {
       type: String,
     },
+    entryUploadDate: {
+      type: Number,
+      required: true,
+    },
   },
   { collection: "entries" }
 );

--- a/pages/api/entries.js
+++ b/pages/api/entries.js
@@ -2,14 +2,14 @@ import dbConnect from "../../db/connect.js";
 import Entry from "../../db/models/Entry.js";
 
 const handler = async (request, response) => {
-  const { recentEntries } = request.query;
+  const { recentEntriesAmount } = request.query;
   await dbConnect();
 
-  if (request.method === "GET" && recentEntries) {
+  if (request.method === "GET" && recentEntriesAmount) {
     try {
       const entries = await Entry.find({})
         .sort({ entryUploadDate: -1 })
-        .limit(recentEntries);
+        .limit(recentEntriesAmount);
 
       response
         .status(200)

--- a/pages/api/entries.js
+++ b/pages/api/entries.js
@@ -1,0 +1,47 @@
+import dbConnect from "../../db/connect.js";
+import Entry from "../../db/models/Entry.js";
+
+const handler = async (request, response) => {
+  const { recentEntries } = request.query;
+  await dbConnect();
+
+  if (request.method === "GET" && recentEntries) {
+    try {
+      const entries = await Entry.find({})
+        .sort({ entryUploadDate: -1 })
+        .limit(recentEntries);
+
+      response
+        .status(200)
+        .json({ status: "Success get recent entries!", data: entries });
+      return;
+    } catch (error) {
+      console.log(error);
+
+      response
+        .status(400)
+        .json({ status: "Failure get recent entries!", error: error.message });
+      return;
+    }
+  }
+
+  if (request.method === "GET") {
+    try {
+      const entries = await Entry.find({});
+
+      response
+        .status(200)
+        .json({ status: "Success get entries!", data: entries });
+      return;
+    } catch (error) {
+      console.log(error);
+
+      response
+        .status(400)
+        .json({ status: "Failure get entries!", error: error.message });
+      return;
+    }
+  }
+};
+
+export default handler;

--- a/pages/api/entry.js
+++ b/pages/api/entry.js
@@ -8,7 +8,6 @@ const handler = async (request, response) => {
   if (request.method === "POST") {
     try {
       const entry = request.body;
-      console.log(entry);
       await Entry.create(entry);
 
       response.status(201).json({ status: "Success entry post!" });

--- a/pages/content.js
+++ b/pages/content.js
@@ -1,6 +1,7 @@
 // Components
 import CommonHeaderLayout from "../components/CommonHeaderLayout";
 import BackButton from "../components/BackButton/BackButton";
+import EntryPreviewList from "../components/EntryPreviewList";
 import NewEntryButton from "../components/NewEntryButton";
 
 const Content = ({ sideBarOpen, setSideBarOpen }) => {
@@ -11,6 +12,7 @@ const Content = ({ sideBarOpen, setSideBarOpen }) => {
         setSideBarOpen={setSideBarOpen}
       />
       <BackButton />
+      <EntryPreviewList />
       <NewEntryButton />
     </>
   );


### PR DESCRIPTION
Please take a moment to review this ❤️
Goal: [US7](https://github.com/dimitriosxmi/ArtistsReferenceOrganizer/issues/7) TL; DR Add an `Entry preview list` of `Entry preview`'s in the dashboard `/` route page under `Recent uploads,` and also apply the list in the content page.

[Deployment](https://artists-reference-organizer-kwlou8g4c-dimitriosxmi.vercel.app/)

```diff
+ Add EntryPreview component
+ Add Entry PreviewList component
# Uses a list of EntryPreview component.
# Handles the calling of 2 GET requests:
# 1. Plain /api/entries.js.
# 2. Just like one but with a paremeter named recentEntriesAmount that defines the number of recently uploaded entries to fetch.

+ Add entries.js api page
# Handles 2 variants of GET methods:
# 1. For fetching all entries.
# 2. For fetching speciffic amount of the latest uploaded entries.

! Update Content page
# Now uses the EntryPreviewList component.

! Update RecentUploads component
# Now uses the EntryPreviewList component (with certain parameters to limit and sort the received data).

! Update entry.js api page
# Remove unnecessary console log.

! Update Entry model
# Added entryUploadDate field.

! Update NewEntryForm component
# Add a timestamp to the entryUploadDate field of the entry before creation.
```