### PR TITLE
Feature/us8/folder view

### DIFF
--- a/components/BackButton/BackButton.js
+++ b/components/BackButton/BackButton.js
@@ -15,6 +15,7 @@ const BackButton = () => {
 
 export default BackButton;
 
+//#region Styled Objects
 const StyledArrowLeftLong = styled(ArrowLeftLong)`
   z-index: -1;
   color: #333;
@@ -33,3 +34,4 @@ const StyledLink = styled.div`
   width: 45px;
   height: 45px;
 `;
+//#endregion

--- a/components/Breadcrumb/index.js
+++ b/components/Breadcrumb/index.js
@@ -9,7 +9,7 @@ const Breadcrumb = () => {
   //#region Router
   const router = useRouter();
   const routePath = router.asPath;
-  const routerParams = router.query;
+  const { folderId } = router.query;
   //#endregion
 
   //#region Breadcrumb text setup
@@ -28,18 +28,16 @@ const Breadcrumb = () => {
         case "/new-entry":
           setBreadcrumbText("(NEW ENTRY)");
           break;
-        case `/folder/${routerParams.folderId}`:
+        case `/folder/${folderId}`:
           (async () => {
             // Get folder by id
-            const response = await fetch(
-              `/api/folder?folderId=${routerParams.folderId}`
-            );
+            const response = await fetch(`/api/folder?folderId=${folderId}`);
 
             if (response.ok) {
-              // Refine data
-              const jsonData = await response.json();
-              const cleanData = jsonData.data;
-              const folderName = cleanData.folderName;
+              // Nested destructure the folderName out of data.
+              const {
+                data: { folderName },
+              } = await response.json();
 
               setBreadcrumbText(`Dashboard/ folder/ ${folderName}`);
             }
@@ -50,11 +48,13 @@ const Breadcrumb = () => {
           break;
       }
     })(routePath);
-  }, [routePath, routerParams]);
+  }, [routePath, folderId]);
   //#endregion
 
   return <StyledBreadcrumb>{breadcrumbText}</StyledBreadcrumb>;
 };
+
+export default Breadcrumb;
 
 const StyledBreadcrumb = styled.p`
   text-align: center;
@@ -62,5 +62,3 @@ const StyledBreadcrumb = styled.p`
   border-bottom: 2px solid #223;
   padding: 5px;
 `;
-
-export default Breadcrumb;

--- a/components/Breadcrumb/index.js
+++ b/components/Breadcrumb/index.js
@@ -4,11 +4,12 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
 
 const Breadcrumb = () => {
-  const [breadcrumbText, setBreadcrumbText] = useState("");
+  const [breadcrumbText, setBreadcrumbText] = useState("Loading..");
 
   //#region Router
   const router = useRouter();
   const routePath = router.asPath;
+  const routerParams = router.query;
   //#endregion
 
   //#region Breadcrumb text setup
@@ -27,12 +28,29 @@ const Breadcrumb = () => {
         case "/new-entry":
           setBreadcrumbText("(NEW ENTRY)");
           break;
+        case `/folder/${routerParams.folderId}`:
+          (async () => {
+            // Get folder by id
+            const response = await fetch(
+              `/api/folder?folderId=${routerParams.folderId}`
+            );
+
+            if (response.ok) {
+              // Refine data
+              const jsonData = await response.json();
+              const cleanData = jsonData.data;
+              const folderName = cleanData.folderName;
+
+              setBreadcrumbText(`Dashboard/ folder/ ${folderName}`);
+            }
+          })();
+          break;
         default:
           setBreadcrumbText("Unknown Page");
           break;
       }
     })(routePath);
-  }, [routePath]);
+  }, [routePath, routerParams]);
   //#endregion
 
   return <StyledBreadcrumb>{breadcrumbText}</StyledBreadcrumb>;

--- a/components/EntryPreview/index.js
+++ b/components/EntryPreview/index.js
@@ -10,6 +10,7 @@ const EntryPreview = ({ entryData }) => {
 
 export default EntryPreview;
 
+//#region Styled Objects
 const StyledEntryPreviewCard = styled.div`
   width: 90%;
   height: 75px;
@@ -30,3 +31,4 @@ const StyledEntryName = styled.p`
   overflow: hidden;
   text-overflow: ellipsis;
 `;
+//#endregion

--- a/components/EntryPreviewList/index.js
+++ b/components/EntryPreviewList/index.js
@@ -54,7 +54,7 @@ const EntryPreviewList = ({ recentEntriesAmount, hasData, folderId }) => {
         throw new Error(error.message);
       }
     })();
-  }, []);
+  }, [folderId, hasData, recentEntriesAmount]);
   //#endregion
 
   if (!entries) return <p>Loading entries..</p>;

--- a/components/EntryPreviewList/index.js
+++ b/components/EntryPreviewList/index.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 // Components
 import EntryPreview from "../EntryPreview";
 
-const EntryPreviewList = ({ recentEntriesAmount, hasData }) => {
+const EntryPreviewList = ({ recentEntriesAmount, hasData, folderId }) => {
   const [entries, setEntries] = useState([]);
 
   //#region Get entries from database
@@ -21,6 +21,19 @@ const EntryPreviewList = ({ recentEntriesAmount, hasData }) => {
             const cleanData = jsonData.data;
             setEntries(cleanData);
             if (hasData) hasData(cleanData);
+          }
+        }
+        //#endregion
+        //#region Get entries of specific folder
+        else if (folderId) {
+          const response = await fetch(
+            `/api/entries?selectedFolderId=${folderId}`
+          );
+
+          if (response.ok) {
+            const jsonData = await response.json();
+            const cleanData = jsonData.data;
+            setEntries(cleanData);
           }
         }
         //#endregion

--- a/components/EntryPreviewList/index.js
+++ b/components/EntryPreviewList/index.js
@@ -17,10 +17,9 @@ const EntryPreviewList = ({ recentEntriesAmount, hasData, folderId }) => {
           );
 
           if (response.ok) {
-            const jsonData = await response.json();
-            const cleanData = jsonData.data;
-            setEntries(cleanData);
-            if (hasData) hasData(cleanData);
+            const { data } = await response.json();
+            setEntries(data);
+            if (hasData) hasData(data);
           }
         }
         //#endregion
@@ -31,9 +30,8 @@ const EntryPreviewList = ({ recentEntriesAmount, hasData, folderId }) => {
           );
 
           if (response.ok) {
-            const jsonData = await response.json();
-            const cleanData = jsonData.data;
-            setEntries(cleanData);
+            const { data } = await response.json();
+            setEntries(data);
           }
         }
         //#endregion
@@ -42,10 +40,9 @@ const EntryPreviewList = ({ recentEntriesAmount, hasData, folderId }) => {
           const response = await fetch("/api/entries");
 
           if (response.ok) {
-            const jsonData = await response.json();
-            const cleanData = jsonData.data;
-            setEntries(cleanData);
-            if (hasData) hasData(cleanData);
+            const { data } = await response.json();
+            setEntries(data);
+            if (hasData) hasData(data);
           }
         }
         //#endregion

--- a/components/FolderPreviewButton/index.js
+++ b/components/FolderPreviewButton/index.js
@@ -14,6 +14,7 @@ const FolderPreviewButton = ({ data }) => {
 
 export default FolderPreviewButton;
 
+//#region Styled Objects
 const StyledFolderIcon = styled(FolderIcon)`
   z-index: 0;
   width: 100%;
@@ -37,3 +38,4 @@ const StyledParagraphText = styled.p`
   position: relative;
   bottom: 5%;
 `;
+//#endregion

--- a/components/FolderPreviewButton/index.js
+++ b/components/FolderPreviewButton/index.js
@@ -1,17 +1,18 @@
 import styled from "styled-components";
+import Link from "next/link";
 // SVGs
 import { FolderIcon } from "../svgs";
 
-const FolderPreviewIcon = ({ data }) => {
+const FolderPreviewButton = ({ data }) => {
   return (
-    <StyledFolder>
+    <StyledFolderLink href={`/folder/${data._id}`}>
       <StyledFolderIcon foldercolor={data.folderColor} />
       <StyledParagraphText>{data.folderName}</StyledParagraphText>
-    </StyledFolder>
+    </StyledFolderLink>
   );
 };
 
-export default FolderPreviewIcon;
+export default FolderPreviewButton;
 
 const StyledFolderIcon = styled(FolderIcon)`
   z-index: 0;
@@ -20,7 +21,8 @@ const StyledFolderIcon = styled(FolderIcon)`
   color: ${({ foldercolor }) => foldercolor};
 `;
 
-const StyledFolder = styled.div`
+const StyledFolderLink = styled(Link)`
+  display: inline-block;
   z-index: 1;
   width: 30%;
   text-decoration: none;

--- a/components/FolderPreviewList/index.js
+++ b/components/FolderPreviewList/index.js
@@ -2,7 +2,7 @@ import styled from "styled-components";
 // Hooks
 import { useState, useEffect } from "react";
 
-import FolderPreviewIcon from "../FolderPreviewIcon";
+import FolderPreviewButton from "../FolderPreviewButton";
 import NewFolderButton from "../NewFolderButton";
 
 const FolderPreviewList = () => {
@@ -31,7 +31,7 @@ const FolderPreviewList = () => {
   return (
     <StyledFolderPreviewList>
       {dataFolders.map((folderData) => {
-        return <FolderPreviewIcon key={folderData._id} data={folderData} />;
+        return <FolderPreviewButton key={folderData._id} data={folderData} />;
       })}
       <NewFolderButton />
     </StyledFolderPreviewList>

--- a/components/FolderPreviewList/index.js
+++ b/components/FolderPreviewList/index.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 // Hooks
 import { useState, useEffect } from "react";
-
+// Components
 import FolderPreviewButton from "../FolderPreviewButton";
 import NewFolderButton from "../NewFolderButton";
 
@@ -11,14 +11,14 @@ const FolderPreviewList = () => {
   useEffect(() => {
     (async () => {
       try {
+        // GET all folders.
         const response = await fetch("/api/folders", {
           method: "GET",
         });
 
         if (response.ok) {
-          const jsonData = await response.json();
-          const cleanData = jsonData.data;
-          setDataFolders(cleanData);
+          const { data } = await response.json();
+          setDataFolders(data);
         }
       } catch (error) {
         throw new Error(error.message);

--- a/components/NewEntryButton/index.js
+++ b/components/NewEntryButton/index.js
@@ -3,9 +3,11 @@ import Link from "next/link";
 // SVGs
 import { EntryFileIcon, PlusIcon } from "../svgs";
 
-const NewEntryButton = () => {
+const NewEntryButton = ({ folderId }) => {
   return (
-    <StyledLink href="/new-entry">
+    <StyledLink
+      href={folderId ? `/new-entry?folderId=${folderId}` : `/new-entry`}
+    >
       <StyledEntryFileIcon />
       <StyledPlusIcon />
       <StyledParagraphText>(NEW ENTRY)</StyledParagraphText>

--- a/components/NewEntryButton/index.js
+++ b/components/NewEntryButton/index.js
@@ -17,6 +17,7 @@ const NewEntryButton = ({ folderId }) => {
 
 export default NewEntryButton;
 
+//#region Styled Objects
 const StyledEntryFileIcon = styled(EntryFileIcon)`
   position: relative;
   z-index: 1;
@@ -55,3 +56,4 @@ const StyledParagraphText = styled.p`
   position: relative;
   bottom: 225%;
 `;
+//#endregion

--- a/components/NewEntryForm/index.js
+++ b/components/NewEntryForm/index.js
@@ -28,7 +28,9 @@ const NewEntryForm = () => {
     const formData = new FormData(event.target);
     const data = Object.fromEntries(formData);
     data.entryUploadDate = new Date().valueOf();
-    folderId ? (data.entrySelectedFolder = folderId) : null;
+    !data.entrySelectedFolder && folderId
+      ? (data.entrySelectedFolder = folderId)
+      : null;
     const response = await fetch("/api/entry", {
       method: "POST",
       headers: {

--- a/components/NewEntryForm/index.js
+++ b/components/NewEntryForm/index.js
@@ -27,10 +27,14 @@ const NewEntryForm = () => {
     event.preventDefault();
     const formData = new FormData(event.target);
     const data = Object.fromEntries(formData);
+    // Apply current new Date as timestamp.
     data.entryUploadDate = new Date().valueOf();
+    // Selected folder not provided AND folderId provided
+    // apply folderId to selected folder.
     !data.entrySelectedFolder && folderId
       ? (data.entrySelectedFolder = folderId)
       : null;
+    // POST the entry.
     const response = await fetch("/api/entry", {
       method: "POST",
       headers: {
@@ -51,6 +55,7 @@ const NewEntryForm = () => {
 
 export default NewEntryForm;
 
+//#region Styled Objects
 const StyledInput = styled.input`
   margin: 20px 0 20px 5%;
   border: 2px dashed #448;
@@ -75,3 +80,4 @@ const StyledSubmitButton = styled.button`
   border-radius: 10px;
   background: #40cc90;
 `;
+//#endregion

--- a/components/NewEntryForm/index.js
+++ b/components/NewEntryForm/index.js
@@ -6,6 +6,7 @@ import { PlusIcon } from "../svgs";
 
 const NewEntryForm = () => {
   const router = useRouter();
+  const { folderId } = router.query;
 
   return (
     <form onSubmit={handleOnSubmit}>
@@ -27,6 +28,7 @@ const NewEntryForm = () => {
     const formData = new FormData(event.target);
     const data = Object.fromEntries(formData);
     data.entryUploadDate = new Date().valueOf();
+    folderId ? (data.entrySelectedFolder = folderId) : null;
     const response = await fetch("/api/entry", {
       method: "POST",
       headers: {
@@ -36,6 +38,10 @@ const NewEntryForm = () => {
     });
 
     if (response.ok) {
+      if (folderId) {
+        router.push(`/folder/${folderId}`);
+        return;
+      }
       router.push("/");
     }
   }

--- a/components/NewFolderButton/index.js
+++ b/components/NewFolderButton/index.js
@@ -15,6 +15,7 @@ const NewFolderButton = () => {
 
 export default NewFolderButton;
 
+//#region Styled Objects
 const StyledFolderIcon = styled(FolderIcon)`
   position: relative;
   z-index: 0;
@@ -51,3 +52,4 @@ const StyledParagraphText = styled.p`
   position: relative;
   bottom: 110px;
 `;
+//#endregion

--- a/components/NewFolderForm/index.js
+++ b/components/NewFolderForm/index.js
@@ -50,8 +50,10 @@ const NewFolderForm = () => {
     event.preventDefault();
     const formData = new FormData(event.target);
     const data = Object.fromEntries(formData);
+    // Add selected folderColor to data.
     const fullData = { ...data, folderColor: folderColor };
 
+    // POST the folder.
     const response = await fetch("/api/folder", {
       method: "POST",
       headers: {

--- a/components/SideBar/index.js
+++ b/components/SideBar/index.js
@@ -1,11 +1,7 @@
 import styled from "styled-components";
 import Link from "next/link";
-// Hooks
-import { useRouter } from "next/router";
 
 const SideBar = ({ sideBarOpen, setSideBarOpen }) => {
-  const router = useRouter();
-
   return sideBarOpen ? (
     <>
       <StyledSideBarBackground onClick={() => handleOnClickBackground()} />
@@ -22,11 +18,9 @@ const SideBar = ({ sideBarOpen, setSideBarOpen }) => {
     </>
   ) : null;
 
-  //#region Click handler function
   function handleOnClickBackground() {
     setSideBarOpen();
   }
-  //#endregion
 };
 
 export default SideBar;

--- a/components/SideBarButton/index.js
+++ b/components/SideBarButton/index.js
@@ -21,7 +21,6 @@ const SidebarButton = ({ sideBarOpen, setSideBarOpen }) => {
 
 export default SidebarButton;
 
-//#region Styled Objects
 const StyledBurgerButton = styled.button`
   z-index: 200;
   position: absolute;
@@ -34,4 +33,3 @@ const StyledBurgerButton = styled.button`
   color: #333;
   background-color: white;
 `;
-//#endregion

--- a/pages/api/entries.js
+++ b/pages/api/entries.js
@@ -2,7 +2,7 @@ import dbConnect from "../../db/connect.js";
 import Entry from "../../db/models/Entry.js";
 
 const handler = async (request, response) => {
-  const { recentEntriesAmount } = request.query;
+  const { recentEntriesAmount, selectedFolderId } = request.query;
   await dbConnect();
 
   if (request.method === "GET" && recentEntriesAmount) {
@@ -21,6 +21,26 @@ const handler = async (request, response) => {
       response
         .status(400)
         .json({ status: "Failure get recent entries!", error: error.message });
+      return;
+    }
+  }
+
+  if (request.method === "GET" && selectedFolderId) {
+    try {
+      const entries = await Entry.find({
+        entrySelectedFolder: selectedFolderId,
+      });
+
+      response
+        .status(200)
+        .json({ status: "Sucess get folder entries!", data: entries });
+      return;
+    } catch (error) {
+      console.log(error);
+
+      response
+        .status(400)
+        .json({ status: "Failure get folder entries!", error: error.message });
       return;
     }
   }

--- a/pages/api/entries.js
+++ b/pages/api/entries.js
@@ -1,10 +1,12 @@
 import dbConnect from "../../db/connect.js";
+// Models
 import Entry from "../../db/models/Entry.js";
 
 const handler = async (request, response) => {
   const { recentEntriesAmount, selectedFolderId } = request.query;
   await dbConnect();
 
+  // Get specific amount of most recent.
   if (request.method === "GET" && recentEntriesAmount) {
     try {
       const entries = await Entry.find({})
@@ -25,6 +27,7 @@ const handler = async (request, response) => {
     }
   }
 
+  // Get all with folder id.
   if (request.method === "GET" && selectedFolderId) {
     try {
       const entries = await Entry.find({
@@ -45,6 +48,7 @@ const handler = async (request, response) => {
     }
   }
 
+  // Get all data.
   if (request.method === "GET") {
     try {
       const entries = await Entry.find({});

--- a/pages/api/entry.js
+++ b/pages/api/entry.js
@@ -5,6 +5,7 @@ import Entry from "../../db/models/Entry.js";
 const handler = async (request, response) => {
   await dbConnect();
 
+  // POST an entry.
   if (request.method === "POST") {
     try {
       const entry = request.body;

--- a/pages/api/folder.js
+++ b/pages/api/folder.js
@@ -6,6 +6,7 @@ const handler = async (request, response) => {
   const { folderId } = request.query;
   await dbConnect();
 
+  // Get folder by id.
   if (request.method === "GET" && folderId) {
     try {
       const folder = await Folder.findById(folderId);
@@ -24,6 +25,7 @@ const handler = async (request, response) => {
     }
   }
 
+  // POST a folder.
   if (request.method === "POST") {
     try {
       const folder = request.body;

--- a/pages/api/folder.js
+++ b/pages/api/folder.js
@@ -3,7 +3,26 @@ import dbConnect from "../../db/connect.js";
 import Folder from "../../db/models/Folder.js";
 
 const handler = async (request, response) => {
+  const { folderId } = request.query;
   await dbConnect();
+
+  if (request.method === "GET" && folderId) {
+    try {
+      const folder = await Folder.findById(folderId);
+
+      response
+        .status(200)
+        .json({ status: "Success to get folder!", data: folder });
+      return;
+    } catch (error) {
+      console.log(error);
+
+      response
+        .status(400)
+        .json({ status: "Faillure to get folder!", error: error.message });
+      return;
+    }
+  }
 
   if (request.method === "POST") {
     try {

--- a/pages/api/folders.js
+++ b/pages/api/folders.js
@@ -5,6 +5,7 @@ import Folder from "../../db/models/Folder.js";
 const handler = async (request, response) => {
   await dbConnect();
 
+  // GET all folders.
   if (request.method === "GET") {
     try {
       const folders = await Folder.find();

--- a/pages/folder/[folderId].js
+++ b/pages/folder/[folderId].js
@@ -1,0 +1,28 @@
+// Hooks
+import { useRouter } from "next/router";
+
+// Components
+import CommonHeaderLayout from "../../components/CommonHeaderLayout";
+import BackButton from "../../components/BackButton/BackButton.js";
+import NewEntryButton from "../../components/NewEntryButton";
+import EntryPreviewList from "../../components/EntryPreviewList";
+
+const FolderView = ({ sideBarOpen, setSideBarOpen }) => {
+  const router = useRouter();
+  const routerParams = router.query;
+  const folderId = routerParams.folderId;
+
+  return (
+    <>
+      <CommonHeaderLayout
+        sideBarOpen={sideBarOpen}
+        setSideBarOpen={setSideBarOpen}
+      />
+      <BackButton />
+      <NewEntryButton folderId={folderId} />
+      <EntryPreviewList folderId={folderId} />
+    </>
+  );
+};
+
+export default FolderView;

--- a/pages/folder/[folderId].js
+++ b/pages/folder/[folderId].js
@@ -9,8 +9,7 @@ import EntryPreviewList from "../../components/EntryPreviewList";
 
 const FolderView = ({ sideBarOpen, setSideBarOpen }) => {
   const router = useRouter();
-  const routerParams = router.query;
-  const folderId = routerParams.folderId;
+  const { folderId } = router.query;
 
   return (
     <>


### PR DESCRIPTION
Please take a moment to review this ❤️
Goal: [US8](https://github.com/dimitriosxmi/ArtistsReferenceOrganizer/issues/8) TL; DR: Add a `Folder view` page accessible through a click on an existing folder, creating new entry from a folder sets the folder selection of the entry to the specific folder it was called from.

[Deployment](https://artists-reference-organizer-dxy74hntz-dimitriosxmi.vercel.app/)

```diff
+ Add folder/[folderId].js page
# Displays the entry list of a folder.

! Update Breadcrumb component
# To support the new page and deliver an adaptive breadcrumb.

! Update entries.js api page
# Handles the GET method for specific folderId related entries.

! Update EntryPreviewList component
# Added fetch with folderId router params to get only entries of the specific folder.

! Update FolderPreviewButton component
# Renamed from FolderPreviewIcon to FolderPreviewButton.
# Uses a link now instead of a div.

! Update FolderPreviewList component
# Applies the new FolderPreviewButton component name.

! Update folder.js api page
# Handles the GET method for getting a folder by id.

! Update NewEntryButton component
# Catches from props the folderId and provides it with the new route.

! Update NewEntryForm component
# Catches the folderId router param and provides it to the newly created entry
# if the entry doesn't already have a selected folder Id value.
```