### PR TITLE
Feature/us10/delete folder button

### DIFF
--- a/components/DeleteButton/index.js
+++ b/components/DeleteButton/index.js
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 // Components
 import DeleteRequest from "../DeleteRequest";
 
-const DeleteButton = ({ text, deleteAPIUrl }) => {
+const DeleteButton = ({ text, deleteAPIUrl, folderId }) => {
   const [isRequestingDelete, setIsRequestingDelete] = useState(false);
 
   return (
@@ -22,6 +22,7 @@ const DeleteButton = ({ text, deleteAPIUrl }) => {
           text={text.toLowerCase()}
           setIsRequestingDelete={setIsRequestingDelete}
           deleteAPIUrl={deleteAPIUrl}
+          folderId={folderId ? folderId : null}
         />
       ) : null}
     </>

--- a/components/DeleteButton/index.js
+++ b/components/DeleteButton/index.js
@@ -1,0 +1,41 @@
+import styled from "styled-components";
+// Hooks
+import { useState, useEffect } from "react";
+// Components
+import DeleteRequest from "../DeleteRequest";
+
+const DeleteButton = ({ text, deleteAPIUrl }) => {
+  const [isRequestingDelete, setIsRequestingDelete] = useState(false);
+
+  return (
+    <>
+      <StyledButton
+        type="button"
+        onClick={() => {
+          setIsRequestingDelete(!isRequestingDelete);
+        }}
+      >
+        ❌ Delete {text}
+      </StyledButton>
+      {isRequestingDelete ? (
+        <DeleteRequest
+          text={text.toLowerCase()}
+          setIsRequestingDelete={setIsRequestingDelete}
+          deleteAPIUrl={deleteAPIUrl}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default DeleteButton;
+
+const StyledButton = styled.button`
+  position: absolute;
+  top: 110px;
+  right: 10px;
+  border-radius: 10px;
+  background: #faa;
+  border: 2px solid #223;
+  font-size: 1.5rem;
+`;

--- a/components/DeleteRequest/index.js
+++ b/components/DeleteRequest/index.js
@@ -2,9 +2,13 @@ import styled from "styled-components";
 // Hooks
 import { useRouter } from "next/router";
 
-const DeleteRequest = ({ text, setIsRequestingDelete, deleteAPIUrl }) => {
+const DeleteRequest = ({
+  text,
+  setIsRequestingDelete,
+  deleteAPIUrl,
+  folderId,
+}) => {
   const router = useRouter();
-  const { folderId } = router.query;
 
   return (
     <>
@@ -19,11 +23,33 @@ const DeleteRequest = ({ text, setIsRequestingDelete, deleteAPIUrl }) => {
           </StyledButton>
         </StyledButtonContainer>
       </StyledDeleteRequestBox>
-      <StyledSideBarBackground onClick={() => handleOnClickCancel()} />
+      <StyledBackground onClick={() => handleOnClickCancel()} />
     </>
   );
 
+  // If folder id isn't provided, than just delete
   async function handleOnClickDelete() {
+    folderId ? await handleUpdateRelatedEntries() : handleDeleteFolder();
+  }
+
+  async function handleUpdateRelatedEntries() {
+    // PUT update entries.
+    // (Triggers functionality on api end that deletes
+    // entrySelectedFolder property from a selection of entries).
+    const postResponse = await fetch(
+      `/api/entries?selectedFolderId=${folderId}`,
+      {
+        method: "PUT",
+      }
+    );
+
+    if (postResponse.ok) {
+      handleDeleteFolder();
+    }
+  }
+
+  async function handleDeleteFolder() {
+    // Delete entry or folder. (depends on the provided api url)
     const response = await fetch(deleteAPIUrl, {
       method: "DELETE",
     });
@@ -33,6 +59,7 @@ const DeleteRequest = ({ text, setIsRequestingDelete, deleteAPIUrl }) => {
     }
   }
 
+  // Close delete request window.
   function handleOnClickCancel() {
     setIsRequestingDelete(false);
   }
@@ -78,7 +105,7 @@ const StyledButton = styled.button`
   border-radius: 10px;
 `;
 
-const StyledSideBarBackground = styled.div`
+const StyledBackground = styled.div`
   z-index: 200;
   position: fixed;
   left: 0;

--- a/components/DeleteRequest/index.js
+++ b/components/DeleteRequest/index.js
@@ -1,0 +1,90 @@
+import styled from "styled-components";
+// Hooks
+import { useRouter } from "next/router";
+
+const DeleteRequest = ({ text, setIsRequestingDelete, deleteAPIUrl }) => {
+  const router = useRouter();
+  const { folderId } = router.query;
+
+  return (
+    <>
+      <StyledDeleteRequestBox>
+        <StyledText>Are you sure you want to delete this {text}.</StyledText>
+        <StyledButtonContainer>
+          <StyledButton deleteBtn onClick={() => handleOnClickDelete()}>
+            Delete
+          </StyledButton>
+          <StyledButton onClick={() => handleOnClickCancel()}>
+            Cancel
+          </StyledButton>
+        </StyledButtonContainer>
+      </StyledDeleteRequestBox>
+      <StyledSideBarBackground onClick={() => handleOnClickCancel()} />
+    </>
+  );
+
+  async function handleOnClickDelete() {
+    const response = await fetch(deleteAPIUrl, {
+      method: "DELETE",
+    });
+
+    if (response.ok) {
+      router.push("/");
+    }
+  }
+
+  function handleOnClickCancel() {
+    setIsRequestingDelete(false);
+  }
+};
+
+export default DeleteRequest;
+
+//#region Styled Objects
+const StyledDeleteRequestBox = styled.div`
+  z-index: 201;
+  position: relative;
+  top: 10px;
+  left: 5%;
+  width: 90%;
+  border: 2px solid #223;
+  border-radius: 10px;
+  background-color: #faa;
+`;
+
+const StyledText = styled.p`
+  z-index: 1;
+  font-size: 1.5rem;
+  text-align: center;
+  width: 90%;
+  margin: 5% 0 5% 5%;
+`;
+
+const StyledButtonContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 90%;
+  height: 100%;
+  margin: 0 0 5% 5%;
+`;
+
+const StyledButton = styled.button`
+  width: 45%;
+  height: 100%;
+  font-size: 1.5rem;
+  font-weight: 600;
+  background-color: ${({ deleteBtn }) => (deleteBtn ? "#f55" : "#bbb")};
+  border: 2px solid #223;
+  border-radius: 10px;
+`;
+
+const StyledSideBarBackground = styled.div`
+  z-index: 200;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: #4489;
+`;
+//#endregion

--- a/pages/[entryId].js
+++ b/pages/[entryId].js
@@ -1,9 +1,15 @@
+// Hooks
+import { useRouter } from "next/router";
 // Components
 import CommonHeaderLayout from "../components/CommonHeaderLayout";
 import BackButton from "../components/BackButton/BackButton.js";
+import DeleteButton from "../components/DeleteButton";
 import EntryDetails from "../components/EntryDetails";
 
 const EntryView = ({ sideBarOpen, setSideBarOpen }) => {
+  const router = useRouter();
+  const { entryId } = router.query;
+
   return (
     <>
       <CommonHeaderLayout
@@ -11,6 +17,10 @@ const EntryView = ({ sideBarOpen, setSideBarOpen }) => {
         setSideBarOpen={setSideBarOpen}
       />
       <BackButton />
+      <DeleteButton
+        text={"Entry"}
+        deleteAPIUrl={`/api/entry?entryId=${entryId}`}
+      />
       <EntryDetails />
     </>
   );

--- a/pages/api/entries.js
+++ b/pages/api/entries.js
@@ -66,6 +66,27 @@ const handler = async (request, response) => {
       return;
     }
   }
+
+  // Update (remove entrySelectedFolder field) on all entries by folder id.
+  if (request.method === "PUT" && selectedFolderId) {
+    try {
+      await Entry.updateMany(
+        { entrySelectedFolder: selectedFolderId },
+        { $unset: { entrySelectedFolder: "" } }
+      );
+
+      response.status(200).json({ status: "Success put provided entries!" });
+      return;
+    } catch (error) {
+      console.log(error);
+
+      response.status(400).json({
+        status: "Failure put provided entries!",
+        error: error.message,
+      });
+      return;
+    }
+  }
 };
 
 export default handler;

--- a/pages/api/entry.js
+++ b/pages/api/entry.js
@@ -42,6 +42,22 @@ const handler = async (request, response) => {
       return;
     }
   }
+
+  // Delete an entry by id.
+  if (request.method === "DELETE" && entryId) {
+    try {
+      await Entry.findByIdAndDelete(entryId);
+
+      response.status(200).json({ status: "Success delete entry by id!" });
+    } catch (error) {
+      consolee.log(error);
+
+      response
+        .status(400)
+        .json({ status: "Failure delete entry by id!", error: error.message });
+      return;
+    }
+  }
 };
 
 export default handler;

--- a/pages/api/folder.js
+++ b/pages/api/folder.js
@@ -42,6 +42,21 @@ const handler = async (request, response) => {
       return;
     }
   }
+
+  // DELETE a folder by id.
+  if (request.method === "DELETE" && folderId) {
+    try {
+      await Folder.findByIdAndDelete(folderId);
+
+      response.status(200).json({ status: "Success delete folder by id!" });
+    } catch (error) {
+      console.log(error);
+
+      response
+        .status(400)
+        .json({ status: "Failure delete folder by id!", error: error.message });
+    }
+  }
 };
 
 export default handler;

--- a/pages/folder/[folderId].js
+++ b/pages/folder/[folderId].js
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 // Components
 import CommonHeaderLayout from "../../components/CommonHeaderLayout";
 import BackButton from "../../components/BackButton/BackButton.js";
+import DeleteButton from "../../components/DeleteButton";
 import NewEntryButton from "../../components/NewEntryButton";
 import EntryPreviewList from "../../components/EntryPreviewList";
 
@@ -18,6 +19,10 @@ const FolderView = ({ sideBarOpen, setSideBarOpen }) => {
         setSideBarOpen={setSideBarOpen}
       />
       <BackButton />
+      <DeleteButton
+        text={"Folder"}
+        deleteAPIUrl={`/api/folder?folderId=${folderId}`}
+      />
       <NewEntryButton folderId={folderId} />
       <EntryPreviewList folderId={folderId} />
     </>

--- a/pages/folder/[folderId].js
+++ b/pages/folder/[folderId].js
@@ -1,6 +1,5 @@
 // Hooks
 import { useRouter } from "next/router";
-
 // Components
 import CommonHeaderLayout from "../../components/CommonHeaderLayout";
 import BackButton from "../../components/BackButton/BackButton.js";
@@ -22,6 +21,7 @@ const FolderView = ({ sideBarOpen, setSideBarOpen }) => {
       <DeleteButton
         text={"Folder"}
         deleteAPIUrl={`/api/folder?folderId=${folderId}`}
+        folderId={folderId}
       />
       <NewEntryButton folderId={folderId} />
       <EntryPreviewList folderId={folderId} />


### PR DESCRIPTION
Please take a moment to review this ❤️
Goal: [US10](https://github.com/dimitriosxmi/ArtistsReferenceOrganizer/issues/17) (and [US11](https://github.com/dimitriosxmi/ArtistsReferenceOrganizer/issues/18)) TL; DR: Folders and Entries must have a delete button, the button must have the same behaviour on both, clicking it will show a delete request window, clicking cancel or outside the window will close it, clicking delete button will delete the given folder or entry. Deleting a folder doesn't delete the entries assigned to it.

[Deployment](https://artists-reference-organizer-42j0573ib-dimitriosxmi.vercel.app/)

```diff
+ Add DeleteRequest component
# Handles the request of DELETE method for deleting a folder/ entry.

+ Add DeleteButton component
# Handles the toggling on of the Delete Request component.

! Update entry.js api page
# Handles the DELETE method for deleting an entry by id.

! Update folder.js api page
# Handles the DELETE method for deleting a folder by id.

! Update entries.js api page
# Handles the PUT method for removing the entrySelectedFolder
# property from all entries with the specific folder id of the folder
# that is currently being deleted.

! Update /folder/[folderId].js page
# Uses the DeleteButton component.

! Update [entryId].js page
# Uses the DeleteButton component.
```