### PR TITLE
Feature/us14/entry view more details

### DIFF
--- a/components/BackButton/BackButton.js
+++ b/components/BackButton/BackButton.js
@@ -7,7 +7,7 @@ import { ArrowLeftLong } from "../svgs";
 const BackButton = () => {
   const router = useRouter();
   return (
-    <StyledLink onClick={() => router.back()}>
+    <StyledLink onClick={() => router.push(`/`)}>
       <StyledArrowLeftLong width={"2rem"} height={"2rem"} />
     </StyledLink>
   );

--- a/components/EntryDetails/index.js
+++ b/components/EntryDetails/index.js
@@ -8,11 +8,13 @@ const EntryDetails = () => {
   const { entryId } = router.query;
   const [entryData, setEntryData] = useState();
 
+  // GET entry by id from database.
   useEffect(() => {
     (async () => {
       const response = await fetch(`/api/entry?entryId=${entryId}`);
 
       if (response.ok) {
+        // Unpack received data and pass it to entryData state variable.
         const { data } = await response.json();
         setEntryData(data);
       }
@@ -21,9 +23,32 @@ const EntryDetails = () => {
 
   if (!entryData) return <p>Loading..</p>;
 
-  const { entryName } = entryData;
+  const { entryName, entryReferenceLink, entryTags, entryDescription } =
+    entryData;
 
-  return <StyledHeadline>{entryName}</StyledHeadline>;
+  return (
+    <>
+      {/* Name  */}
+      <StyledHeadline>{entryName}</StyledHeadline>
+      {/* Link */}
+      <StyledText bold>Link:</StyledText>
+      <StyledText borderBottom>{entryReferenceLink}</StyledText>
+      {/* Tags */}
+      <StyledTagContainer>
+        <StyledText noMargin bold>
+          Tags:
+        </StyledText>
+        {entryTags.map((tag) => (
+          <StyledTagCard key={tag._id}>{tag.tagName}</StyledTagCard>
+        ))}
+      </StyledTagContainer>
+      {/* Description */}
+      <StyledText borderTop bold>
+        Description:
+      </StyledText>
+      <StyledText>{entryDescription}</StyledText>
+    </>
+  );
 };
 
 export default EntryDetails;
@@ -31,11 +56,43 @@ export default EntryDetails;
 const StyledHeadline = styled.p`
   max-width: 90%;
   margin: 10px 0 0 5%;
-  padding: 5px;
+  padding: 0.5rem;
   font-size: 2rem;
   text-align: center;
   display: block;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+`;
+
+const StyledText = styled.p`
+  max-width: 90%;
+  margin: 0 0 0 5%;
+  padding: 0.5rem;
+  font-size: 1rem;
+  text-align: start;
+  overflow: hidden;
+
+  ${({ bold }) => (bold ? `font-weight: 600;` : null)}
+  ${({ borderTop }) => (borderTop ? `border-top: 2px dashed #223;` : null)}
+  ${({ borderBottom }) =>
+    borderBottom ? `border-bottom: 2px dashed #223;` : null}
+  ${({ noMargin }) => (noMargin ? `margin: 0;` : null)}
+`;
+
+const StyledTagCard = styled.div`
+  margin: 0.125rem 0.25rem;
+  padding: 0 0.25rem;
+  border: 1px solid #223;
+  border-radius: 10px;
+  font-size: 1rem;
+`;
+
+const StyledTagContainer = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: flex-start;
+  align-items: center;
+  width: 90%;
+  padding-left: 5%;
 `;

--- a/components/NewEntryForm/index.js
+++ b/components/NewEntryForm/index.js
@@ -18,7 +18,7 @@ const NewEntryForm = () => {
   });
   const tagInputElement = useRef();
 
-  // GET's the tags list from database.
+  // GET's the tags and folders list from database.
   useEffect(() => {
     (async () => {
       await updateTagsList();
@@ -102,7 +102,7 @@ const NewEntryForm = () => {
           {tags.map((tag) => (
             <StyledTagCard
               key={tag._id}
-              isSelected={selectedTags.includes(tag)}
+              isSelected={selectedTags.find((_tag) => _tag._id === tag._id)}
             >
               <StyledDeleteCardButton
                 type="button"
@@ -113,7 +113,7 @@ const NewEntryForm = () => {
                 type="button"
                 value={tag.tagName}
                 onClick={() => handleOnClickTag(tag)}
-                isSelected={selectedTags.includes(tag)}
+                isSelected={selectedTags.find((_tag) => _tag._id === tag._id)}
               />
             </StyledTagCard>
           ))}
@@ -382,7 +382,7 @@ const StyledTagSelection = styled.div`
 `;
 
 const StyledTagCard = styled.div`
-  margin: 0 0.25rem;
+  margin: 0.125rem 0.25rem;
   padding: 0;
   border: 2px dashed #448;
   border-radius: 10px;


### PR DESCRIPTION
## Please take a moment to review this ❤️ 😊
**Goal**: [US14](https://github.com/dimitriosxmi/ArtistsReferenceOrganizer/issues/21) **TL; DR**: The details page of an entry card willl show more details now.

[Deployment](https://artists-reference-organizer-bvcbgcqq2-dimitriosxmi.vercel.app/)

```diff
! Update EntryDetails component
# Now has a Reference Link text display.
# Now has a Description text display.
# Now has a Tag list text display.

! Update BackButton component
# Now always routes to '/'.

! Update NewEntryForm component
# Fix bug when a new tag was added or
# when an existing tag was removed
# the selected tags highlighting was resetting.
```